### PR TITLE
Fix repository field to prevent NPM warnings.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,12 +5,11 @@
   "description"   : "C++ library for handling zipfiles in node",
   "keywords"      : ["zipfile", "uncompress", "unzip", "zlib"],
   "url"           : "http://github.com/springmeyer/node-zipfile",
-   "repositories" : [
+  "repository"    :
        {
            "type" : "git",
            "url"  : "git://github.com/springmeyer/node-zipfile.git" 
-       } 
-   ],
+       },
   "author"        : "Dane Springmeyer <dane@dbsgeo.com>",
   "contributors"  : [],
   "licenses"      : ["BSD"],


### PR DESCRIPTION
```
npm WARN package.json zipfile@0.4.3 No repository field.
npm WARN package.json zipfile@0.4.3 'repositories' (plural) Not supported.
npm WARN package.json Please pick one as the 'repository' field
```

I see this so often I felt like fixing it!
