### PR TITLE
Revert c++11 building

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -17,19 +17,11 @@
       'sources': [
         'src/node_zipfile.cpp'
       ],
-      'ldflags': [
-        '-Wl,-z,now',
-      ],
       'xcode_settings': {
         'OTHER_LDFLAGS':[
           '-Wl,-bind_at_load'
         ],
-        'GCC_ENABLE_CPP_RTTI': 'YES',
-        'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
-        'MACOSX_DEPLOYMENT_TARGET':'10.8',
-        'CLANG_CXX_LIBRARY': 'libc++',
-        'CLANG_CXX_LANGUAGE_STANDARD':'c++11',
-        'GCC_VERSION': 'com.apple.compilers.llvm.clang.1_0'
+        'GCC_ENABLE_CPP_EXCEPTIONS': 'YES'
       },
       'cflags_cc!': ['-fno-exceptions'],
       'conditions': [

--- a/deps/common-libzip.gypi
+++ b/deps/common-libzip.gypi
@@ -6,10 +6,6 @@
   'target_defaults': {
     'default_configuration': 'Release',
     'msbuild_toolset':'<(toolset)',
-    'cflags_cc' : [
-      '-std=c++11',
-    ],
-    'cflags_cc!': ['-std=gnu++0x','-fno-rtti', '-fno-exceptions'],
     'configurations': {
       'Debug': {
         'defines!': [


### PR DESCRIPTION
Hey @springmeyer,

I was testing to compile without the C++11 flags for clang. Having those flags was causing some issues when using gcc.

This is more about validating we actually don't need C++11, and it works also in TravisCI.

This is related to your comments at https://github.com/mapbox/node-zipfile/issues/72#issuecomment-267729479.