### PR TITLE
Node 8+ support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ addons:
   apt:
     sources:
      - ubuntu-toolchain-r-test
-     - llvm-toolchain-precise-3.5
+     - llvm-toolchain-precise-3.6
     packages:
-     - clang-3.5
+     - clang-3.6
 
 matrix:
   include:
@@ -67,8 +67,8 @@ before_install:
  - scripts/validate_tag.sh
  - export COVERAGE=${COVERAGE:-false}
  - if [[ $(uname -s) == 'Linux' ]]; then
-     export CXX="clang++-3.5";
-     export CC="clang-3.5";
+     export CXX="clang++-3.6";
+     export CC="clang-3.6";
      export PYTHONPATH=$(pwd)/mason_packages/.link/lib/python2.7/site-packages;
    else
      export PYTHONPATH=$(pwd)/mason_packages/.link/lib/python/site-packages;

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,6 @@ matrix:
      - os: linux
        compiler: clang
        env: NODE_VERSION="4" # node abi 46
-     - os: linux
-       compiler: clang
-       env: NODE_VERSION="0.10" # node abi 11
      # OS X
      - os: osx
        compiler: clang
@@ -55,9 +52,6 @@ matrix:
      - os: osx
        compiler: clang
        env: NODE_VERSION="4" # node abi 46
-     - os: osx
-       compiler: clang
-       env: NODE_VERSION="0.10" # node abi 11
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,16 @@ matrix:
      # Linux
      - os: linux
        compiler: clang
-       env: NODE_VERSION="7" # node abi 48
+       env: NODE_VERSION="10" # node abi 64
+     - os: linux
+       compiler: clang
+       env: NODE_VERSION="9" # node abi 59
+     - os: linux
+       compiler: clang
+       env: NODE_VERSION="8" # node abi 57
+     - os: linux
+       compiler: clang
+       env: NODE_VERSION="7" # node abi 51
      - os: linux
        compiler: clang
        env: NODE_VERSION="6" # node abi 48
@@ -30,7 +39,16 @@ matrix:
      # OS X
      - os: osx
        compiler: clang
-       env: NODE_VERSION="7" # node abi 47
+       env: NODE_VERSION="10" # node abi 64
+     - os: osx
+       compiler: clang
+       env: NODE_VERSION="9" # node abi 59
+     - os: osx
+       compiler: clang
+       env: NODE_VERSION="8" # node abi 57
+     - os: osx
+       compiler: clang
+       env: NODE_VERSION="7" # node abi 51
      - os: osx
        compiler: clang
        env: NODE_VERSION="6" # node abi 47

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,10 @@ addons:
 
 matrix:
   include:
-     # Coverage
-     - os: osx
-       compiler: clang
-       env: NODE_VERSION="4" COVERAGE=true # node abi 46
+     # Coverage: Disabled pending migration to Codecov
+     #- os: osx
+       #compiler: clang
+       #env: NODE_VERSION="4" COVERAGE=true # node abi 46
      # Linux
      - os: linux
        compiler: clang

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,40 +4,40 @@ environment:
   matrix:
     - nodejs_version: 4
       platform: x86
-      msvs_toolset: 12
+      msvs_toolset: 14
     - nodejs_version: 4
       platform: x64
-      msvs_toolset: 12
+      msvs_toolset: 14
     - nodejs_version: 6
       platform: x86
-      msvs_toolset: 12
+      msvs_toolset: 14
     - nodejs_version: 6
       platform: x64
-      msvs_toolset: 12
+      msvs_toolset: 14
     - nodejs_version: 7
       platform: x86
-      msvs_toolset: 12
+      msvs_toolset: 14
     - nodejs_version: 7
       platform: x64
-      msvs_toolset: 12
+      msvs_toolset: 14
     - nodejs_version: 8
       platform: x86
-      msvs_toolset: 12
+      msvs_toolset: 14
     - nodejs_version: 8
       platform: x64
-      msvs_toolset: 12
+      msvs_toolset: 14
     - nodejs_version: 9
       platform: x86
-      msvs_toolset: 12
+      msvs_toolset: 14
     - nodejs_version: 9
       platform: x64
-      msvs_toolset: 12
+      msvs_toolset: 14
     - nodejs_version: 10
       platform: x86
-      msvs_toolset: 12
+      msvs_toolset: 14
     - nodejs_version: 10
       platform: x64
-      msvs_toolset: 12
+      msvs_toolset: 14
 
 install:
   # add local node to path (since we install it for msvs_toolset == 14)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,40 +40,8 @@ environment:
       msvs_toolset: 14
 
 install:
-  # add local node to path (since we install it for msvs_toolset == 14)
-  - SET PATH=%CD%;%PATH%;
-  # add local node-pre-gyp dir to path
-  - SET PATH=node_modules\.bin;%PATH%
-  # use 64 bit python if platform is 64 bit
-  - if "%PLATFORM%" == "x64" set PATH=C:\Python27-x64;%PATH%
-  - SET ARCHPATH=
-  - if %platform% == x64 (SET ARCHPATH=x64/)
-  # install node version per visual studio toolset
-  - if "%msvs_toolset%" == "12" powershell Install-Product node $env:nodejs_version $env:Platform
-  - if "%msvs_toolset%" == "14" powershell Write-Output "fetching https://mapbox.s3.amazonaws.com/node-cpp11/v$env:nodejs_version/${env:ARCHPATH}node.exe"
-  - if "%msvs_toolset%" == "14" powershell Start-FileDownload "https://mapbox.s3.amazonaws.com/node-cpp11/v$env:nodejs_version/${env:ARCHPATH}node.exe"
-  - node -v
-  - node -e "console.log(process.argv,process.execPath)"
-  - SET PATH=C:\Program Files (x86)\MSBuild\%msvs_toolset%.0\bin;%PATH%
-  - SET PATH=C:\Program Files (x86)\Microsoft Visual Studio %msvs_toolset%.0\VC\bin;%PATH%
-  - if %platform% == x64 CALL "C:\Program Files (x86)\Microsoft Visual Studio %msvs_toolset%.0\VC\vcvarsall.bat" amd64
-  - if %platform% == x86 CALL "C:\Program Files (x86)\Microsoft Visual Studio %msvs_toolset%.0\VC\vcvarsall.bat" amd64_x86
-  - npm install --build-from-source --msvs_version=2013 %TOOLSET_ARGS% --loglevel=http
-  - node_modules\.bin\node-pre-gyp reveal module --silent > module.txt
-  - SET /p MODULE=<module.txt
-  - del module.txt
-  - node -e "console.log(process.execPath)" > node_path.txt
-  - SET /p NODE_EXE_PATH=<node_path.txt
-  - del node_path.txt
-  # should display MSVCP140.dll if build with visual studio 2014 and /MD
-  - dumpbin /DEPENDENTS "%NODE_EXE_PATH%"
-  - dumpbin /DEPENDENTS "%MODULE%"
-  - npm test
-  - node-pre-gyp package %TOOLSET_ARGS%
-  # make commit message env var shorter
-  - SET CM=%APPVEYOR_REPO_COMMIT_MESSAGE%
-  - if not "%CM%" == "%CM:[publish binary]=%" node-pre-gyp --msvs_version=2013 publish %TOOLSET_ARGS%
-  - if not "%CM%" == "%CM:[republish binary]=%" node-pre-gyp --msvs_version=2013 unpublish publish %TOOLSET_ARGS%
+  - ps: Start-FileDownload 'https://github.com/mapbox/ci-scripts/raw/v1.1.0/node/ci-cpp.bat' -FileName ci.bat
+  - CALL ci.bat
 
 build: OFF
 test: OFF

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,12 +2,6 @@ os: Visual Studio 2015
 
 environment:
   matrix:
-    - nodejs_version: 0.10
-      platform: x86
-      msvs_toolset: 12
-    - nodejs_version: 0.10
-      platform: x64
-      msvs_toolset: 12
     - nodejs_version: 4
       platform: x86
       msvs_toolset: 12

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,6 +26,24 @@ environment:
     - nodejs_version: 7
       platform: x64
       msvs_toolset: 12
+    - nodejs_version: 8
+      platform: x86
+      msvs_toolset: 12
+    - nodejs_version: 8
+      platform: x64
+      msvs_toolset: 12
+    - nodejs_version: 9
+      platform: x86
+      msvs_toolset: 12
+    - nodejs_version: 9
+      platform: x64
+      msvs_toolset: 12
+    - nodejs_version: 10
+      platform: x86
+      msvs_toolset: 12
+    - nodejs_version: 10
+      platform: x64
+      msvs_toolset: 12
 
 install:
   # add local node to path (since we install it for msvs_toolset == 14)

--- a/bench/largefile.js
+++ b/bench/largefile.js
@@ -5,7 +5,7 @@ var zipfile = require('../lib');
 var assert = require('assert');
 var crypto = require('crypto');
 var shasum = crypto.createHash('md5');
-var queue = require('queue-async');
+var d3 = require('d3-queue');
 
 /*
 
@@ -44,7 +44,7 @@ function unzip(err) {
     var zf = new zipfile.ZipFile(filepath);
     console.timeEnd('opening');
     console.time('copying');
-    var q = queue(10);
+    var q = d3.queue(10);
     zf.names.forEach(function(name) {
         q.defer(copy,zf,name);
     })

--- a/binding.gyp
+++ b/binding.gyp
@@ -54,6 +54,7 @@
     {
       'target_name': 'action_after_build',
       'type': 'none',
+      "win_delay_load_hook": "false",
       'dependencies': [ '<(module_name)' ],
       'copies': [
           {

--- a/deps/libzip.gyp
+++ b/deps/libzip.gyp
@@ -40,6 +40,7 @@
     {
       'target_name': 'action_before_build',
       'type': 'none',
+      "win_delay_load_hook": "false",
       'hard_dependency': 1,
       'actions': [
         {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@mapbox/cloudfriend": "^1.9.1",
-    "aws-sdk": "2.x",
+    "aws-sdk": "^2.266.1",
     "mkdirp": "~0.5.1",
     "mocha": "~2.3.3",
     "queue-async": "~1.2.1"

--- a/package.json
+++ b/package.json
@@ -30,9 +30,6 @@
     "mkdirp": "~0.5.1",
     "mocha": "~5.2.0"
   },
-  "bundledDependencies": [
-    "node-pre-gyp"
-  ],
   "bin": {
     "unzip.js": "./bin/unzip.js"
   },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "node-pre-gyp": "~0.10.2"
   },
   "devDependencies": {
-    "@mapbox/cloudfriend": "^1.9.0",
+    "@mapbox/cloudfriend": "^1.9.1",
     "aws-sdk": "2.x",
     "mkdirp": "~0.5.1",
     "mocha": "~2.3.3",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@mapbox/cloudfriend": "^1.9.1",
     "aws-sdk": "^2.266.1",
     "mkdirp": "~0.5.1",
-    "mocha": "~2.3.3",
+    "mocha": "~5.2.0",
     "queue-async": "~1.2.1"
   },
   "bundledDependencies": [

--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
   "devDependencies": {
     "@mapbox/cloudfriend": "^1.9.1",
     "aws-sdk": "^2.266.1",
+    "d3-queue": "^3.0.7",
     "mkdirp": "~0.5.1",
-    "mocha": "~5.2.0",
-    "queue-async": "~1.2.1"
+    "mocha": "~5.2.0"
   },
   "bundledDependencies": [
     "node-pre-gyp"

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "BSD"
   ],
   "dependencies": {
-    "nan": "~2.4.0",
-    "node-pre-gyp": "~0.6.30"
+    "nan": "~2.10.0",
+    "node-pre-gyp": "~0.10.2"
   },
   "devDependencies": {
     "@mapbox/cloudfriend": "^1.9.0",


### PR DESCRIPTION
I was getting this error when building from source with node 10:
```
  CXX(target) Release/obj.target/zipfile/src/node_zipfile.o
In file included from ../node_modules/nan/nan.h:190,
                 from ../src/node_zipfile.hpp:9,
                 from ../src/node_zipfile.cpp:1:
../node_modules/nan/nan_maybe_43_inl.h: In function ‘Nan::Maybe<bool> Nan::ForceSet(v8::Local<v8::Object>, v8::Local<v8::Value>, v8::Local<v8::Value>, v8::PropertyAttribute)’
../node_modules/nan/nan_maybe_43_inl.h:88:15: error: ‘class v8::Object’ has no member named ‘ForceSet’
   return obj->ForceSet(GetCurrentContext(), key, value, attribs);
```

Since installing it using the precompiled module works I guess that someone did it manually at some point. 